### PR TITLE
Feat: SquareButtonContainer 컴포넌트 추가

### DIFF
--- a/src/components/SquareButtonContainer/index.tsx
+++ b/src/components/SquareButtonContainer/index.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import * as S from './styles';
+import { SquareButton } from '@/components/SquareButton';
+
+interface ButtonItem {
+  id: string;
+  label: string;
+  onClick?: () => void;
+}
+
+interface SquareButtonContainerProps {
+  buttonList: Array<ButtonItem>;
+}
+
+export const SquareButtonContainer = ({ buttonList }: SquareButtonContainerProps) => {
+  const [activeButtonId, setActiveButtonId] = useState<string | null>(buttonList[0]?.id || null);
+
+  return (
+    <S.SquareButtonContainer>
+      {buttonList.map(({ id, label, onClick }) => (
+        <SquareButton
+          key={id}
+          label={label}
+          isActive={id === activeButtonId}
+          onClick={() => {
+            setActiveButtonId(id);
+            onClick?.();
+          }}
+        />
+      ))}
+    </S.SquareButtonContainer>
+  );
+};

--- a/src/components/SquareButtonContainer/styles.ts
+++ b/src/components/SquareButtonContainer/styles.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+export const SquareButtonContainer = styled.div`
+  display: inline-flex;
+  border-radius: 4px;
+  overflow-x: auto;
+  white-space: nowrap;
+`;


### PR DESCRIPTION
## 📝 Summary
<!-- PR에 대한 간략한 설명을 적어주세요 -->
- 재사용 가능한 SquareButtonContainer 컴포넌트 추가
- 여러 개의 SquareButton을 그룹화하고 관리하는 데 사용

## ✨ Changes
<!-- 변경된 내용들을 상세히 나열해 주세요 -->
- 버튼 목록을 props로 받아 동적으로 렌더링
- 각 버튼에 고유 id를 사용하여 활성 상태 관리
- 버튼 클릭 시 자동으로 활성 상태 업데이트

## 🖼️ Screenshots
<!-- 필요한 경우 스크린샷을 첨부해 주세요 -->
<img width="961" alt="image" src="https://github.com/user-attachments/assets/8a9b8a82-cc05-4e9f-82dd-ad3984adab3e">

## 🤔 Checklist
<!-- PR 작성자가 확인해야 할 사항들을 나열해 주세요 -->
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 콘솔 로그나 주석은 없나요?

## 🔗 References
<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->
- Issue: https://github.com/prgrms-fe-devcourse/NFE1-2-LocalStage/issues/59

## 💬 Comments
<!-- 추가적인 커멘트가 있다면 작성해 주세요 -->
