### PR TITLE
Feat: PDetailReviewInput 컴포넌트 구현

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -11,11 +11,11 @@ export const Header = () => {
         <S.SearchBarContainer>
           <S.SearchBar placeholder="공연을 검색해보세요." />
           <S.SearchIcon>
-            <S.StyledFontAwesomeIcon icon={faSearch} isSearch />
+            <S.StyledFontAwesomeIcon icon={faSearch} $isSearch />
           </S.SearchIcon>
         </S.SearchBarContainer>
         <S.IconContainer>
-          <S.StyledFontAwesomeIcon icon={faRankingStar} isRanked />
+          <S.StyledFontAwesomeIcon icon={faRankingStar} $isRanked />
           <S.StyledFontAwesomeIcon icon={faUser} />
         </S.IconContainer>
       </S.StyledHeader>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -15,7 +15,7 @@ export const Header = () => {
           </S.SearchIcon>
         </S.SearchBarContainer>
         <S.IconContainer>
-          <S.StyledFontAwesomeIcon icon={faRankingStar} isRangked />
+          <S.StyledFontAwesomeIcon icon={faRankingStar} isRanked />
           <S.StyledFontAwesomeIcon icon={faUser} />
         </S.IconContainer>
       </S.StyledHeader>

--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -62,8 +62,8 @@ export const IconContainer = styled.div`
   }
 `;
 
-export const StyledFontAwesomeIcon = styled(FontAwesomeIcon)<{ isRangked?: boolean; isSearch?: boolean }>`
+export const StyledFontAwesomeIcon = styled(FontAwesomeIcon)<{ isRanked?: boolean; isSearch?: boolean }>`
   font-size: ${({ isSearch }) => (isSearch ? '15px' : '25px')};
-  color: ${({ theme, isRangked }) => (isRangked ? theme.colors.primary : theme.colors.black)};
+  color: ${({ theme, isRanked }) => (isRanked ? theme.colors.primary : theme.colors.black)};
   cursor: pointer;
 `;

--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -62,8 +62,8 @@ export const IconContainer = styled.div`
   }
 `;
 
-export const StyledFontAwesomeIcon = styled(FontAwesomeIcon)<{ isRanked?: boolean; isSearch?: boolean }>`
-  font-size: ${({ isSearch }) => (isSearch ? '15px' : '25px')};
-  color: ${({ theme, isRanked }) => (isRanked ? theme.colors.primary : theme.colors.black)};
+export const StyledFontAwesomeIcon = styled(FontAwesomeIcon)<{ $isRanked?: boolean; $isSearch?: boolean }>`
+  font-size: ${({ $isSearch }) => ($isSearch ? '15px' : '25px')};
+  color: ${({ theme, $isRanked }) => ($isRanked ? theme.colors.primary : theme.colors.black)};
   cursor: pointer;
 `;

--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -4,7 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 export const HeaderContainer = styled.header`
   width: 100%;
-  border-bottom: 1px solid ${props => props.theme.colors.grey};
+  border-bottom: 1px solid ${props => props.theme.colors.gray};
 `;
 
 export const StyledHeader = styled.div`
@@ -36,7 +36,7 @@ export const SearchBar = styled.input`
   padding: 10px 40px 10px 20px;
   border-radius: 50px;
   outline: none;
-  border: 1px solid ${props => props.theme.colors.grey};
+  border: 1px solid ${props => props.theme.colors.gray};
 
   &::placeholder {
     color: ${props => props.theme.colors.text_gray};

--- a/src/components/PDetailReviewInput/index.tsx
+++ b/src/components/PDetailReviewInput/index.tsx
@@ -1,5 +1,5 @@
 import * as S from './styles';
 
 export const PDetailReviewInput = ({ ...rest }: React.TextareaHTMLAttributes<HTMLTextAreaElement>) => {
-  return <S.PDetailReviewInput {...rest} />;
+  return <S.PDetailReviewInput placeholder="공연에 대한 리뷰를 남겨주세요." {...rest} />;
 };

--- a/src/components/PDetailReviewInput/index.tsx
+++ b/src/components/PDetailReviewInput/index.tsx
@@ -1,41 +1,54 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import * as S from './styles';
 
 interface PDetailReviewInputProps {
   placeholder?: string;
   value: string;
   onChange?: (value: string) => void;
+  onSubmit?: (value: string) => void;
+  disabled?: boolean;
 }
 
 export const PDetailReviewInput = ({
   placeholder = '공연에 대한 리뷰를 남겨주세요.',
   value,
   onChange,
+  onSubmit,
+  disabled = false,
 }: PDetailReviewInputProps) => {
   const [isFocused, setIsFocused] = useState(false);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  const onSubmitForm = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!value.trim() || disabled) return;
+    onSubmit?.(value);
+  };
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (e.key === 'Enter' && !e.shiftKey && !disabled) {
       e.preventDefault();
-      if (onChange) {
-        onChange(value);
-      }
+      onSubmitForm(e as unknown as React.FormEvent<HTMLFormElement>);
     }
   };
 
-  const isFocus = () => setIsFocused(true);
+  const isFocus = () => !disabled && setIsFocused(true);
   const isBlur = () => setIsFocused(false);
 
   return (
-    <S.PDetailReviewInput
-      placeholder={placeholder}
-      value={value}
-      onChange={e => onChange?.(e.target.value)}
-      onKeyDown={onKeyDown}
-      onFocus={isFocus}
-      onBlur={isBlur}
-      $isFocused={isFocused}
-      $hasValue={!!value}
-    />
+    <form onSubmit={onSubmitForm}>
+      <S.PDetailReviewInput
+        ref={inputRef}
+        placeholder={placeholder}
+        value={value}
+        onChange={e => !disabled && onChange?.(e.target.value)}
+        onKeyDown={onKeyDown}
+        onFocus={isFocus}
+        onBlur={isBlur}
+        $isFocused={isFocused}
+        $hasValue={!!value}
+        $disabled={disabled}
+      />
+    </form>
   );
 };

--- a/src/components/PDetailReviewInput/index.tsx
+++ b/src/components/PDetailReviewInput/index.tsx
@@ -1,32 +1,5 @@
-import React, { useState } from 'react';
 import * as S from './styles';
 
-interface PDetailReviewInputProps {
-  placeholder?: string;
-  value: string;
-  onChange?: (value: string) => void;
-  disabled?: boolean;
-}
-
-export const PDetailReviewInput = ({
-  placeholder = '공연에 대한 리뷰를 남겨주세요.',
-  value,
-  onChange,
-  disabled = false,
-}: PDetailReviewInputProps) => {
-  const [isFocused, setIsFocused] = useState(false);
-
-  return (
-    <S.PDetailReviewInput
-      placeholder={placeholder}
-      value={value}
-      onChange={e => !disabled && onChange?.(e.target.value)}
-      onFocus={() => setIsFocused(true)}
-      onBlur={() => setIsFocused(false)}
-      disabled={disabled}
-      $isFocused={isFocused}
-      $hasValue={!!value}
-      $disabled={disabled}
-    />
-  );
+export const PDetailReviewInput = ({ ...rest }: React.TextareaHTMLAttributes<HTMLTextAreaElement>) => {
+  return <S.PDetailReviewInput {...rest} />;
 };

--- a/src/components/PDetailReviewInput/index.tsx
+++ b/src/components/PDetailReviewInput/index.tsx
@@ -1,11 +1,10 @@
-import React, { useState, useRef } from 'react';
+import React, { useState } from 'react';
 import * as S from './styles';
 
 interface PDetailReviewInputProps {
   placeholder?: string;
   value: string;
   onChange?: (value: string) => void;
-  onSubmit?: (value: string) => void;
   disabled?: boolean;
 }
 
@@ -13,42 +12,21 @@ export const PDetailReviewInput = ({
   placeholder = '공연에 대한 리뷰를 남겨주세요.',
   value,
   onChange,
-  onSubmit,
   disabled = false,
 }: PDetailReviewInputProps) => {
   const [isFocused, setIsFocused] = useState(false);
-  const inputRef = useRef<HTMLTextAreaElement>(null);
-
-  const onSubmitForm = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    if (!value.trim() || disabled) return;
-    onSubmit?.(value);
-  };
-
-  const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter' && !e.shiftKey && !disabled) {
-      e.preventDefault();
-      onSubmitForm(e as unknown as React.FormEvent<HTMLFormElement>);
-    }
-  };
-
-  const isFocus = () => !disabled && setIsFocused(true);
-  const isBlur = () => setIsFocused(false);
 
   return (
-    <form onSubmit={onSubmitForm}>
-      <S.PDetailReviewInput
-        ref={inputRef}
-        placeholder={placeholder}
-        value={value}
-        onChange={e => !disabled && onChange?.(e.target.value)}
-        onKeyDown={onKeyDown}
-        onFocus={isFocus}
-        onBlur={isBlur}
-        $isFocused={isFocused}
-        $hasValue={!!value}
-        $disabled={disabled}
-      />
-    </form>
+    <S.PDetailReviewInput
+      placeholder={placeholder}
+      value={value}
+      onChange={e => !disabled && onChange?.(e.target.value)}
+      onFocus={() => setIsFocused(true)}
+      onBlur={() => setIsFocused(false)}
+      disabled={disabled}
+      $isFocused={isFocused}
+      $hasValue={!!value}
+      $disabled={disabled}
+    />
   );
 };

--- a/src/components/PDetailReviewInput/index.tsx
+++ b/src/components/PDetailReviewInput/index.tsx
@@ -1,13 +1,41 @@
+import React, { useState } from 'react';
 import * as S from './styles';
 
 interface PDetailReviewInputProps {
   placeholder?: string;
+  value: string;
+  onChange?: (value: string) => void;
 }
 
-export const PDetailReviewInput = ({ placeholder = '공연에 대한 리뷰를 남겨주세요.' }: PDetailReviewInputProps) => {
+export const PDetailReviewInput = ({
+  placeholder = '공연에 대한 리뷰를 남겨주세요.',
+  value,
+  onChange,
+}: PDetailReviewInputProps) => {
+  const [isFocused, setIsFocused] = useState(false);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      if (onChange) {
+        onChange(value);
+      }
+    }
+  };
+
+  const handleFocus = () => setIsFocused(true);
+  const handleBlur = () => setIsFocused(false);
+
   return (
-    <S.PDetailReviewInput>
-      <S.PDetailReviewTextArea placeholder={placeholder} disabled />
-    </S.PDetailReviewInput>
+    <S.PDetailReviewInput
+      placeholder={placeholder}
+      value={value}
+      onChange={e => onChange?.(e.target.value)}
+      onKeyDown={handleKeyDown}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      $isFocused={isFocused}
+      $hasValue={!!value}
+    />
   );
 };

--- a/src/components/PDetailReviewInput/index.tsx
+++ b/src/components/PDetailReviewInput/index.tsx
@@ -1,0 +1,13 @@
+import * as S from './styles';
+
+interface PDetailReviewInputProps {
+  placeholder?: string;
+}
+
+export const PDetailReviewInput = ({ placeholder = '공연에 대한 리뷰를 남겨주세요.' }: PDetailReviewInputProps) => {
+  return (
+    <S.PDetailReviewInput>
+      <S.PDetailReviewTextArea placeholder={placeholder} disabled />
+    </S.PDetailReviewInput>
+  );
+};

--- a/src/components/PDetailReviewInput/index.tsx
+++ b/src/components/PDetailReviewInput/index.tsx
@@ -14,7 +14,7 @@ export const PDetailReviewInput = ({
 }: PDetailReviewInputProps) => {
   const [isFocused, setIsFocused] = useState(false);
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+  const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       if (onChange) {
@@ -23,17 +23,17 @@ export const PDetailReviewInput = ({
     }
   };
 
-  const handleFocus = () => setIsFocused(true);
-  const handleBlur = () => setIsFocused(false);
+  const isFocus = () => setIsFocused(true);
+  const isBlur = () => setIsFocused(false);
 
   return (
     <S.PDetailReviewInput
       placeholder={placeholder}
       value={value}
       onChange={e => onChange?.(e.target.value)}
-      onKeyDown={handleKeyDown}
-      onFocus={handleFocus}
-      onBlur={handleBlur}
+      onKeyDown={onKeyDown}
+      onFocus={isFocus}
+      onBlur={isBlur}
       $isFocused={isFocused}
       $hasValue={!!value}
     />

--- a/src/components/PDetailReviewInput/styles.ts
+++ b/src/components/PDetailReviewInput/styles.ts
@@ -7,8 +7,6 @@ export const PDetailReviewInput = styled.textarea`
   border: 1px solid ${({ theme }) => theme.colors.gray};
   border-radius: 10px;
   resize: none;
-
-  color: ${({ theme }) => theme.colors.black};
   background-color: ${({ theme }) => theme.colors.gray};
 
   &::placeholder {

--- a/src/components/PDetailReviewInput/styles.ts
+++ b/src/components/PDetailReviewInput/styles.ts
@@ -8,7 +8,7 @@ export const PDetailReviewInput = styled.textarea`
   border-radius: 10px;
   resize: none;
 
-  color: ${({ theme }) => theme.colors.text_black};
+  color: ${({ theme }) => theme.colors.black};
   background-color: ${({ theme }) => theme.colors.gray};
 
   &::placeholder {

--- a/src/components/PDetailReviewInput/styles.ts
+++ b/src/components/PDetailReviewInput/styles.ts
@@ -1,12 +1,12 @@
-import { styled, css } from 'styled-components';
+import styled from 'styled-components';
 
-interface PDetailReviewInputProps {
+interface StyledPDetailReviewInputProps {
   $isFocused: boolean;
   $hasValue: boolean;
   $disabled: boolean;
 }
 
-export const PDetailReviewInput = styled.textarea<PDetailReviewInputProps>`
+export const PDetailReviewInput = styled.textarea<StyledPDetailReviewInputProps>`
   width: 100%;
   height: 100px;
   padding: 10px;
@@ -25,10 +25,4 @@ export const PDetailReviewInput = styled.textarea<PDetailReviewInputProps>`
   &:focus {
     outline: none;
   }
-
-  ${({ $disabled }) =>
-    $disabled &&
-    css`
-      cursor: default;
-    `}
 `;

--- a/src/components/PDetailReviewInput/styles.ts
+++ b/src/components/PDetailReviewInput/styles.ts
@@ -3,18 +3,19 @@ import { styled, css } from 'styled-components';
 interface PDetailReviewInputProps {
   $isFocused: boolean;
   $hasValue: boolean;
+  $disabled: boolean;
 }
 
 export const PDetailReviewInput = styled.textarea<PDetailReviewInputProps>`
-  width: 400px;
+  width: 100%;
   height: 100px;
   padding: 10px;
   border: 1px solid ${({ theme }) => theme.colors.gray};
   border-radius: 10px;
   resize: none;
-  background-color: ${({ theme, $isFocused, $hasValue }) =>
-    $hasValue || $isFocused ? theme.colors.white : theme.colors.bg_gray};
-  cursor: text;
+  background-color: ${({ theme, $isFocused, $hasValue, $disabled }) =>
+    $hasValue || $isFocused || $disabled ? theme.colors.white : theme.colors.bg_gray};
+  cursor: ${({ $disabled }) => ($disabled ? 'default' : 'text')};
   color: ${({ theme }) => theme.colors.text_black};
 
   &::placeholder {
@@ -25,8 +26,8 @@ export const PDetailReviewInput = styled.textarea<PDetailReviewInputProps>`
     outline: none;
   }
 
-  ${({ $hasValue }) =>
-    $hasValue &&
+  ${({ $disabled }) =>
+    $disabled &&
     css`
       cursor: default;
     `}

--- a/src/components/PDetailReviewInput/styles.ts
+++ b/src/components/PDetailReviewInput/styles.ts
@@ -1,30 +1,33 @@
-import { styled } from 'styled-components';
+import { styled, css } from 'styled-components';
 
-export const PDetailReviewInput = styled.div`
+interface PDetailReviewInputProps {
+  $isFocused: boolean;
+  $hasValue: boolean;
+}
+
+export const PDetailReviewInput = styled.textarea<PDetailReviewInputProps>`
   width: 400px;
   height: 100px;
   padding: 10px;
-  background-color: ${props => props.theme.colors.white};
-  border: 1px solid ${props => props.theme.colors.grey};
+  border: 1px solid ${({ theme }) => theme.colors.gray};
   border-radius: 10px;
-`;
-
-export const PDetailReviewTextArea = styled.textarea`
-  width: 100%;
-  height: 100px;
-  padding: 10px;
-  border: none;
-  background-color: transparent;
   resize: none;
+  background-color: ${({ theme, $isFocused, $hasValue }) =>
+    $hasValue || $isFocused ? theme.colors.white : theme.colors.bg_gray};
   cursor: text;
+  color: ${({ theme }) => theme.colors.text_black};
 
-  &:disabled {
-    background-color: #f5f5f5;
-  }
   &::placeholder {
-    color: ${props => props.theme.colors.text_gray};
+    color: ${({ theme }) => theme.colors.text_gray};
   }
+
   &:focus {
     outline: none;
   }
+
+  ${({ $hasValue }) =>
+    $hasValue &&
+    css`
+      cursor: default;
+    `}
 `;

--- a/src/components/PDetailReviewInput/styles.ts
+++ b/src/components/PDetailReviewInput/styles.ts
@@ -1,0 +1,30 @@
+import { styled } from 'styled-components';
+
+export const PDetailReviewInput = styled.div`
+  width: 400px;
+  height: 100px;
+  padding: 10px;
+  background-color: ${props => props.theme.colors.white};
+  border: 1px solid ${props => props.theme.colors.grey};
+  border-radius: 10px;
+`;
+
+export const PDetailReviewTextArea = styled.textarea`
+  width: 100%;
+  height: 100px;
+  padding: 10px;
+  border: none;
+  background-color: transparent;
+  resize: none;
+  cursor: text;
+
+  &:disabled {
+    background-color: #f5f5f5;
+  }
+  &::placeholder {
+    color: ${props => props.theme.colors.text_gray};
+  }
+  &:focus {
+    outline: none;
+  }
+`;

--- a/src/components/PDetailReviewInput/styles.ts
+++ b/src/components/PDetailReviewInput/styles.ts
@@ -1,28 +1,23 @@
 import styled from 'styled-components';
 
-interface StyledPDetailReviewInputProps {
-  $isFocused: boolean;
-  $hasValue: boolean;
-  $disabled: boolean;
-}
-
-export const PDetailReviewInput = styled.textarea<StyledPDetailReviewInputProps>`
+export const PDetailReviewInput = styled.textarea`
   width: 100%;
   height: 100px;
   padding: 10px;
   border: 1px solid ${({ theme }) => theme.colors.gray};
   border-radius: 10px;
   resize: none;
-  background-color: ${({ theme, $isFocused, $hasValue, $disabled }) =>
-    $hasValue || $isFocused || $disabled ? theme.colors.white : theme.colors.bg_gray};
-  cursor: ${({ $disabled }) => ($disabled ? 'default' : 'text')};
+
   color: ${({ theme }) => theme.colors.text_black};
+  background-color: ${({ theme }) => theme.colors.bg_gray};
 
   &::placeholder {
     color: ${({ theme }) => theme.colors.text_gray};
   }
-
   &:focus {
     outline: none;
+  }
+  &:disabled {
+    background-color: ${({ theme }) => theme.colors.white};
   }
 `;

--- a/src/components/PDetailReviewInput/styles.ts
+++ b/src/components/PDetailReviewInput/styles.ts
@@ -9,15 +9,13 @@ export const PDetailReviewInput = styled.textarea`
   resize: none;
 
   color: ${({ theme }) => theme.colors.text_black};
-  background-color: ${({ theme }) => theme.colors.bg_gray};
+  background-color: ${({ theme }) => theme.colors.gray};
 
   &::placeholder {
     color: ${({ theme }) => theme.colors.text_gray};
   }
   &:focus {
     outline: none;
-  }
-  &:disabled {
     background-color: ${({ theme }) => theme.colors.white};
   }
 `;


### PR DESCRIPTION
## 📝 Summary
<!-- PR에 대한 간략한 설명을 적어주세요 -->
상세페이지와 마이페이지에 들어가는 리뷰작성 input 컴포넌트를 구현했습니다.
## ✨ Changes
<!-- 변경된 내용들을 상세히 나열해 주세요 -->
- input의 기본 배경은 gray 로 포커싱이 되면 white로 설정했습니다.
- 리뷰를 입력하면 placeholder가 사라지고 입력값이 표현됩니다.
- 그냥 엔터를 누르면 아직까진 적용되지 않습니다. (이 부분은 부모컴포넌트에서 적용할 예정입니다.)
- 엔터와 스페이스를 함께 누르면 개행이 적용됩니다 

## 🖼️ Screenshots

https://github.com/user-attachments/assets/14dd82d7-1945-4f46-8ef5-b9a0644b79b5



## ✅ PR Checklist
<!-- 코드 리뷰 시 확인해야 할 사항들 -->
- [x] 하나의 목적을 가진 PR입니다.
- [x] 코딩 컨벤션과 스타일 가이드를 준수합니다. [📌Conventions](https://github.com/prgrms-fe-devcourse/NFE1-2-LocalStage/wiki/%F0%9F%93%8CConventions)
- [x] 불필요한 코드 중복이 없습니다.
- [x] 컴포넌트의 책임이 단일합니다.
- [x] 리액트 훅을 올바르게 사용했습니다.
- [x] 민감한 정보를 포함하지 않았습니다.
- [x] 불필요한 콘솔 로그나 주석을 포함하지 않았습니다.
- [ ] 컴포넌트 key값에 고유한 값을 할당했습니다.

## 🔗 References
<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->
- Issue: 

## 💬 Comments
<!-- 추가적인 커멘트가 있다면 작성해 주세요 -->
