### PR TITLE
Feat: PItem 컴포넌트 구현

### DIFF
--- a/src/components/PItem/index.tsx
+++ b/src/components/PItem/index.tsx
@@ -5,12 +5,12 @@ interface PItemProps {
   rank: number;
   title: string;
   area: string;
-  venue: string;
+  location: string;
   period: string;
   posterUrl: string;
 }
 
-export const PItem = ({ rank, title, venue, period, posterUrl, area }: PItemProps) => {
+export const PItem = ({ rank, title, location, period, posterUrl, area }: PItemProps) => {
   return (
     <S.ItemContainer>
       <S.Rank>{rank}</S.Rank>
@@ -18,7 +18,7 @@ export const PItem = ({ rank, title, venue, period, posterUrl, area }: PItemProp
       <S.InfoContainer>
         <S.Title>{title}</S.Title>
         <S.Info>{area}</S.Info>
-        <S.Info>{venue}</S.Info>
+        <S.Info>{location}</S.Info>
         <S.Info>
           <time dateTime={period.replace(' ~ ', '/')}>{period}</time>
         </S.Info>

--- a/src/components/PItem/index.tsx
+++ b/src/components/PItem/index.tsx
@@ -1,0 +1,28 @@
+import * as S from './styles';
+
+interface PItemProps {
+  id: string;
+  rank: number;
+  title: string;
+  area: string;
+  venue: string;
+  period: string;
+  posterUrl: string;
+}
+
+export const PItem = ({ rank, title, venue, period, posterUrl, area }: PItemProps) => {
+  return (
+    <S.ItemContainer>
+      <S.Rank>{rank}</S.Rank>
+      {posterUrl && <S.Poster src={posterUrl} alt={title} />}
+      <S.InfoContainer>
+        <S.Title>{title}</S.Title>
+        <S.Info>{area}</S.Info>
+        <S.Info>{venue}</S.Info>
+        <S.Info>
+          <time dateTime={period.replace(' ~ ', '/')}>{period}</time>
+        </S.Info>
+      </S.InfoContainer>
+    </S.ItemContainer>
+  );
+};

--- a/src/components/PItem/index.tsx
+++ b/src/components/PItem/index.tsx
@@ -1,5 +1,5 @@
+import { HeartButton } from '@/components/HeartButton';
 import * as S from './styles';
-
 interface PItemProps {
   id: string;
   rank: number;
@@ -19,10 +19,9 @@ export const PItem = ({ rank, title, location, period, posterUrl, area }: PItemP
         <S.Title>{title}</S.Title>
         <S.Info>{area}</S.Info>
         <S.Info>{location}</S.Info>
-        <S.Info>
-          <time dateTime={period.replace(' ~ ', '/')}>{period}</time>
-        </S.Info>
+        <S.Info>{period}</S.Info>
       </S.InfoContainer>
+      <HeartButton />
     </S.ItemContainer>
   );
 };

--- a/src/components/PItem/index.tsx
+++ b/src/components/PItem/index.tsx
@@ -1,5 +1,6 @@
 import { HeartButton } from '@/components/HeartButton';
 import * as S from './styles';
+import { Poster } from '@/components/Poster';
 interface PItemProps {
   id: string;
   rank: number;
@@ -14,7 +15,7 @@ export const PItem = ({ rank, title, location, period, posterUrl, area }: PItemP
   return (
     <S.ItemContainer>
       <S.Rank>{rank}</S.Rank>
-      {posterUrl && <S.Poster src={posterUrl} alt={title} />}
+      {posterUrl && <Poster src={posterUrl} width="90px" rank={rank} />}
       <S.InfoContainer>
         <S.Title>{title}</S.Title>
         <S.Info>{area}</S.Info>

--- a/src/components/PItem/styles.ts
+++ b/src/components/PItem/styles.ts
@@ -1,0 +1,42 @@
+import { H16, H24, P14 } from '@/components/Text';
+import styled from 'styled-components';
+
+export const ItemContainer = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 16px;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray};
+`;
+
+export const Rank = styled(H24)`
+  width: 40px;
+  text-align: center;
+  margin-right: 24px;
+`;
+
+export const Poster = styled.img`
+  width: 90px;
+  height: 120px;
+  object-fit: cover;
+  border-radius: 8px;
+  margin-right: 24px;
+`;
+
+export const InfoContainer = styled.div`
+  display: flex;
+  flex: 1;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const Title = styled(H16)`
+  margin: 0;
+  flex: 2;
+`;
+
+export const Info = styled(P14)`
+  margin: 0;
+  flex: 1;
+  text-align: center;
+  color: ${({ theme }) => theme.colors.text_gray};
+`;

--- a/src/components/PItem/styles.ts
+++ b/src/components/PItem/styles.ts
@@ -30,12 +30,10 @@ export const InfoContainer = styled.div`
 `;
 
 export const Title = styled(H16)`
-  margin: 0;
   flex: 2;
 `;
 
 export const Info = styled(P14)`
-  margin: 0;
   flex: 1;
   text-align: center;
   color: ${({ theme }) => theme.colors.text_gray};

--- a/src/components/PItem/styles.ts
+++ b/src/components/PItem/styles.ts
@@ -14,19 +14,12 @@ export const Rank = styled(H24)`
   margin-right: 24px;
 `;
 
-export const Poster = styled.img`
-  width: 90px;
-  height: 120px;
-  object-fit: cover;
-  border-radius: 8px;
-  margin-right: 24px;
-`;
-
 export const InfoContainer = styled.div`
   display: flex;
   flex: 1;
   justify-content: space-between;
   align-items: center;
+  margin-left: 24px;
 `;
 
 export const Title = styled(H16)`

--- a/src/components/PItemContainer/index.tsx
+++ b/src/components/PItemContainer/index.tsx
@@ -1,26 +1,21 @@
+import { Loader } from '@/components/Loader';
 import * as S from './styles';
 import { PItem } from '@/components/PItem';
-import { PListResponseType } from '@/types/apis';
+import { CommonResponseType } from '@/types/apis';
 
 interface PItemContainerProps {
-  data: PListResponseType;
+  data: Pick<CommonResponseType, 'mt20id' | 'prfnm' | 'fcltynm' | 'prfpdfrom' | 'prfpdto' | 'poster' | 'area'>[];
   isLoading: boolean;
 }
 
-// Pick<CommonResponseType,"area"|"mt20id">
-
 export const PItemContainer = ({ data, isLoading }: PItemContainerProps) => {
   if (isLoading) {
-    return <div>로딩 중...</div>;
-  }
-
-  if (!data || !data.dbs || !data.dbs.db) {
-    return <div>데이터를 불러올 수 없습니다.</div>;
+    return <Loader />;
   }
 
   return (
     <S.PItemContainer>
-      {data.dbs.db.map((item, index) => (
+      {data.map((item, index) => (
         <PItem
           key={item.mt20id}
           rank={index + 1}

--- a/src/components/PItemContainer/index.tsx
+++ b/src/components/PItemContainer/index.tsx
@@ -1,7 +1,6 @@
+import * as S from './styles';
 import { PItem } from '@/components/PItem';
-import { CommonResponseType, PListResponseType } from '@/types/apis';
-
-type DbItem = Pick<CommonResponseType, 'mt20id' | 'prfnm' | 'fcltynm' | 'prfpdfrom' | 'prfpdto' | 'poster' | 'area'>;
+import { PListResponseType } from '@/types/apis';
 
 interface PItemContainerProps {
   data: PListResponseType;
@@ -9,26 +8,6 @@ interface PItemContainerProps {
 }
 
 // Pick<CommonResponseType,"area"|"mt20id">
-interface PItemListProps {
-  data: DbItem[];
-}
-
-const PItemList = ({ data = [] }: PItemListProps) => (
-  <>
-    {data.map((item, index) => (
-      <PItem
-        key={item.mt20id}
-        rank={index + 1}
-        id={item.mt20id}
-        title={item.prfnm}
-        location={item.fcltynm}
-        period={`${item.prfpdfrom} ~ ${item.prfpdto}`}
-        posterUrl={item.poster}
-        area={item.area}
-      />
-    ))}
-  </>
-);
 
 export const PItemContainer = ({ data, isLoading }: PItemContainerProps) => {
   if (isLoading) {
@@ -39,5 +18,20 @@ export const PItemContainer = ({ data, isLoading }: PItemContainerProps) => {
     return <div>데이터를 불러올 수 없습니다.</div>;
   }
 
-  return <PItemList data={data.dbs.db} />;
+  return (
+    <S.PItemContainer>
+      {data.dbs.db.map((item, index) => (
+        <PItem
+          key={item.mt20id}
+          rank={index + 1}
+          id={item.mt20id}
+          title={item.prfnm}
+          location={item.fcltynm}
+          period={`${item.prfpdfrom} ~ ${item.prfpdto}`}
+          posterUrl={item.poster}
+          area={item.area}
+        />
+      ))}
+    </S.PItemContainer>
+  );
 };

--- a/src/components/PItemContainer/index.tsx
+++ b/src/components/PItemContainer/index.tsx
@@ -1,47 +1,36 @@
 import { PItem } from '@/components/PItem';
-import usePList from '@/hooks/usePList';
-import { useEffect, useState } from 'react';
+import { CommonResponseType, PListResponseType } from '@/types/apis';
 
-interface PListParams {
-  stdate: string;
-  eddate: string;
-  cpage: number;
-  rows: number;
-  prfstate: string;
-  signgucode: string;
-  sortStdr: string;
+type DbItem = Pick<CommonResponseType, 'mt20id' | 'prfnm' | 'fcltynm' | 'prfpdfrom' | 'prfpdto' | 'poster' | 'area'>;
+
+interface PItemContainerProps {
+  data: PListResponseType | undefined;
+  isLoading: boolean;
 }
 
-export const PItemContainer = () => {
-  const [params, setParams] = useState<PListParams>({
-    stdate: '', // 시작일
-    eddate: '', // 종료일
-    cpage: 1, // 현재 페이지
-    rows: 50, // 불러올 목록
-    prfstate: '02', // 공연중
-    signgucode: '11', // 전국
-    sortStdr: '3', // 관람객 수 기준 내림차순
-  });
+// Pick<CommonResponseType,"area"|"mt20id">
+interface PItemListProps {
+  data: DbItem[];
+}
 
-  useEffect(() => {
-    const today = new Date();
-    const formattedDate = formatDate(today);
-    setParams(prev => ({
-      ...prev,
-      stdate: formattedDate,
-      eddate: formattedDate,
-    }));
-  }, []);
+const PItemList = ({ data }: PItemListProps) => (
+  <>
+    {data.map((item, index) => (
+      <PItem
+        key={item.mt20id}
+        rank={index + 1}
+        id={item.mt20id}
+        title={item.prfnm}
+        location={item.fcltynm}
+        period={`${item.prfpdfrom} ~ ${item.prfpdto}`}
+        posterUrl={item.poster}
+        area={item.area}
+      />
+    ))}
+  </>
+);
 
-  const formatDate = (date: Date): string => {
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
-    return `${year}${month}${day}`;
-  };
-
-  const { data, isLoading } = usePList(params);
-
+export const PItemContainer = ({ data, isLoading }: PItemContainerProps) => {
   if (isLoading) {
     return <div>로딩 중...</div>;
   }
@@ -50,20 +39,5 @@ export const PItemContainer = () => {
     return <div>데이터를 불러올 수 없습니다.</div>;
   }
 
-  return (
-    <>
-      {data.dbs.db.map((item, index) => (
-        <PItem
-          key={item.mt20id}
-          rank={index + 1}
-          id={item.mt20id}
-          title={`${item.prfnm}`}
-          location={item.fcltynm}
-          period={`${item.prfpdfrom} ~ ${item.prfpdto}`}
-          posterUrl={item.poster}
-          area={item.area}
-        />
-      ))}
-    </>
-  );
+  return <PItemList data={data.dbs.db} />;
 };

--- a/src/components/PItemContainer/index.tsx
+++ b/src/components/PItemContainer/index.tsx
@@ -1,0 +1,69 @@
+import { PItem } from '@/components/PItem';
+import usePList from '@/hooks/usePList';
+import { useEffect, useState } from 'react';
+
+interface PListParams {
+  stdate: string;
+  eddate: string;
+  cpage: number;
+  rows: number;
+  prfstate: string;
+  signgucode: string;
+  sortStdr: string;
+}
+
+export const PItemContainer = () => {
+  const [params, setParams] = useState<PListParams>({
+    stdate: '', // 시작일
+    eddate: '', // 종료일
+    cpage: 1, // 현재 페이지
+    rows: 50, // 불러올 목록
+    prfstate: '02', // 공연중
+    signgucode: '11', // 전국
+    sortStdr: '3', // 관람객 수 기준 내림차순
+  });
+
+  useEffect(() => {
+    const today = new Date();
+    const formattedDate = formatDate(today);
+    setParams(prev => ({
+      ...prev,
+      stdate: formattedDate,
+      eddate: formattedDate,
+    }));
+  }, []);
+
+  const formatDate = (date: Date): string => {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}${month}${day}`;
+  };
+
+  const { data, isLoading } = usePList(params);
+
+  if (isLoading) {
+    return <div>로딩 중...</div>;
+  }
+
+  if (!data || !data.dbs || !data.dbs.db) {
+    return <div>데이터를 불러올 수 없습니다.</div>;
+  }
+
+  return (
+    <>
+      {data.dbs.db.map((item, index) => (
+        <PItem
+          key={item.mt20id}
+          rank={index + 1}
+          id={item.mt20id}
+          title={`${item.prfnm}`}
+          venue={item.fcltynm}
+          period={`${item.prfpdfrom} ~ ${item.prfpdto}`}
+          posterUrl={item.poster}
+          area={item.area}
+        />
+      ))}
+    </>
+  );
+};

--- a/src/components/PItemContainer/index.tsx
+++ b/src/components/PItemContainer/index.tsx
@@ -58,7 +58,7 @@ export const PItemContainer = () => {
           rank={index + 1}
           id={item.mt20id}
           title={`${item.prfnm}`}
-          venue={item.fcltynm}
+          location={item.fcltynm}
           period={`${item.prfpdfrom} ~ ${item.prfpdto}`}
           posterUrl={item.poster}
           area={item.area}

--- a/src/components/PItemContainer/index.tsx
+++ b/src/components/PItemContainer/index.tsx
@@ -4,7 +4,7 @@ import { CommonResponseType, PListResponseType } from '@/types/apis';
 type DbItem = Pick<CommonResponseType, 'mt20id' | 'prfnm' | 'fcltynm' | 'prfpdfrom' | 'prfpdto' | 'poster' | 'area'>;
 
 interface PItemContainerProps {
-  data: PListResponseType | undefined;
+  data: PListResponseType;
   isLoading: boolean;
 }
 
@@ -13,7 +13,7 @@ interface PItemListProps {
   data: DbItem[];
 }
 
-const PItemList = ({ data }: PItemListProps) => (
+const PItemList = ({ data = [] }: PItemListProps) => (
   <>
     {data.map((item, index) => (
       <PItem

--- a/src/components/PItemContainer/styles.ts
+++ b/src/components/PItemContainer/styles.ts
@@ -1,0 +1,7 @@
+import { styled } from 'styled-components';
+
+export const PItemContainer = styled.div`
+  width: 100%;
+  max-width: 1280px;
+  margin: 0 auto;
+`;

--- a/src/components/PItemContainer/styles.ts
+++ b/src/components/PItemContainer/styles.ts
@@ -2,6 +2,5 @@ import { styled } from 'styled-components';
 
 export const PItemContainer = styled.div`
   width: 100%;
-  max-width: 1280px;
   margin: 0 auto;
 `;


### PR DESCRIPTION
## 📝 Summary
<!-- PR에 대한 간략한 설명을 적어주세요 -->
장르별 페이지에서 공연 정보를 리스트 형식으로 볼 수 있는 PItem 컴포넌트 추가

## ✨ Changes
<!-- 변경된 내용들을 상세히 나열해 주세요 -->
- PItem 및 PItemContainer 컴포넌트 추가
- usePList 훅을 사용하여  공연 정보 api를 받아와서 props 전달

## 🖼️ Screenshots
<!-- 필요한 경우 스크린샷을 첨부해 주세요 -->
<img width="1331" alt="image" src="https://github.com/user-attachments/assets/8f4151ad-b248-4fe2-b69c-18fe331ee4b9">


## ✅ PR Checklist
<!-- 코드 리뷰 시 확인해야 할 사항들 -->
- [x] 하나의 목적을 가진 PR입니다.
- [x] 코딩 컨벤션과 스타일 가이드를 준수합니다. [📌Conventions](https://github.com/prgrms-fe-devcourse/NFE1-2-LocalStage/wiki/%F0%9F%93%8CConventions)
- [x] 불필요한 코드 중복이 없습니다.
- [x] 컴포넌트의 책임이 단일합니다.
- [x] 리액트 훅을 올바르게 사용했습니다.
- [x] 민감한 정보를 포함하지 않았습니다.
- [x] 불필요한 콘솔 로그나 주석을 포함하지 않았습니다.
- [x] 컴포넌트 key값에 고유한 값을 할당했습니다.

## 🔗 References
<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->
- Issue:  https://github.com/prgrms-fe-devcourse/NFE1-2-LocalStage/issues/104

## 💬 Comments
<!-- 추가적인 커멘트가 있다면 작성해 주세요 -->
HeartButton 및 CrownIcon merge 완료 시 추가 예정