### PR TITLE
Feat: useFetch 캐싱 기능 추가

### DIFF
--- a/src/store/useCacheStore.ts
+++ b/src/store/useCacheStore.ts
@@ -1,0 +1,42 @@
+import { create } from 'zustand';
+
+interface Cache {
+  data: unknown;
+  timestamp: number;
+}
+
+export const useCacheStore = create<{
+  caches: { [url: string]: Cache };
+  hasCache: (url: string) => boolean;
+  registerCache: (url: string, data: unknown) => void;
+  clear: (url: string) => void;
+}>((set, get) => ({
+  caches: {},
+  hasCache: (url: string) => {
+    const cache = get().caches[url];
+    if (!cache) return false;
+    const currentTime = Date.now();
+    const expirationTime = 5 * 60 * 1000; // 5분 (밀리초 단위)
+    return currentTime - cache.timestamp < expirationTime;
+  },
+  registerCache: (url: string, data: unknown) => {
+    if (!get().hasCache(url)) {
+      set(state => ({
+        ...state,
+        caches: {
+          ...state.caches,
+          [url]: {
+            data,
+            timestamp: Date.now(),
+          },
+        },
+      }));
+    }
+  },
+  clear: (url: string) =>
+    set(state => {
+      const restCaches = { ...state.caches };
+      delete restCaches[url];
+      return { ...state, caches: restCaches };
+    }),
+}));


### PR DESCRIPTION
## 📝 Summary
<!-- PR에 대한 간략한 설명을 적어주세요 -->
zustand를 이용해 useFetch에 캐싱 기능을 추가하였습니다.

## ✨ Changes
<!-- 변경된 내용들을 상세히 나열해 주세요 -->
- 같은 api 요청 시 전역 상태로 저장해둔 캐시 값을 검사하여 이미 데이터가 있다면 그 데이터를 불러오고 따로 비동기 요청을 하지 않습니다.

## 🖼️ Screenshots
<!-- 필요한 경우 스크린샷을 첨부해 주세요 -->
없ㅇ므

## ✅ PR Checklist
<!-- 코드 리뷰 시 확인해야 할 사항들 -->
- [ ] 하나의 목적을 가진 PR입니다.
- [ ] 코딩 컨벤션과 스타일 가이드를 준수합니다. [📌Conventions](https://github.com/prgrms-fe-devcourse/NFE1-2-LocalStage/wiki/%F0%9F%93%8CConventions)
- [ ] 불필요한 코드 중복이 없습니다.
- [ ] 컴포넌트의 책임이 단일합니다.
- [ ] 리액트 훅을 올바르게 사용했습니다.
- [ ] 민감한 정보를 포함하지 않았습니다.
- [ ] 불필요한 콘솔 로그나 주석을 포함하지 않았습니다.
- [ ] 컴포넌트 key값에 고유한 값을 할당했습니다.

## 🔗 References
<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->
- Issue: #143

## 💬 Comments
<!-- 추가적인 커멘트가 있다면 작성해 주세요 -->
없음