### PR TITLE
158-feature/PrevButton&NextButton 컴포넌트 구현

### DIFF
--- a/src/components/NextButton/index.tsx
+++ b/src/components/NextButton/index.tsx
@@ -1,0 +1,19 @@
+import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import * as S from './styles';
+
+interface NextButtonProps {
+  onClickNextButton: () => void;
+  disabled: boolean;
+}
+
+export const NextButton = ({ onClickNextButton, disabled }: NextButtonProps) => {
+  const onClick = () => onClickNextButton();
+
+  return (
+    <S.Button onClick={onClick} disabled={disabled}>
+      <S.ButtonText>Next</S.ButtonText>
+      <FontAwesomeIcon icon={faChevronRight} />
+    </S.Button>
+  );
+};

--- a/src/components/NextButton/styles.ts
+++ b/src/components/NextButton/styles.ts
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+
+export const Button = styled.button`
+  display: flex;
+  align-items: center;
+  padding: 5px 10px;
+  background-color: ${({ theme }) => theme.colors.white};
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+
+  &:disabled {
+    cursor: not-allowed;
+  }
+
+  svg {
+    width: 16px;
+    height: 16px;
+    margin-left: 8px; // 이 부분이 변경되었습니다
+  }
+`;
+
+export const ButtonText = styled.span`
+  font-size: 15px;
+  font-weight: 500;
+`;

--- a/src/components/NextButton/styles.ts
+++ b/src/components/NextButton/styles.ts
@@ -16,7 +16,7 @@ export const Button = styled.button`
   svg {
     width: 16px;
     height: 16px;
-    margin-left: 8px; // 이 부분이 변경되었습니다
+    margin-left: 8px;
   }
 `;
 

--- a/src/components/PrevButton/index.tsx
+++ b/src/components/PrevButton/index.tsx
@@ -1,0 +1,19 @@
+import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import * as S from './styles';
+
+interface PrevButtonProps {
+  onClickPrevButton: () => void;
+  disabled: boolean;
+}
+
+export const PrevButton = ({ onClickPrevButton, disabled }: PrevButtonProps) => {
+  const onClick = () => onClickPrevButton();
+
+  return (
+    <S.Button onClick={onClick} disabled={disabled}>
+      <FontAwesomeIcon icon={faChevronLeft} />
+      <S.ButtonText>Previous</S.ButtonText>
+    </S.Button>
+  );
+};

--- a/src/components/PrevButton/styles.ts
+++ b/src/components/PrevButton/styles.ts
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+
+export const Button = styled.button`
+  display: flex;
+  align-items: center;
+  padding: 5px 10px;
+  background-color: ${({ theme }) => theme.colors.white};
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+
+  &:disabled {
+    cursor: not-allowed;
+  }
+
+  svg {
+    width: 16px;
+    height: 16px;
+    margin-right: 8px;
+  }
+`;
+
+export const ButtonText = styled.span`
+  font-size: 15px;
+  font-weight: 500;
+`;


### PR DESCRIPTION
## 📝 Summary
<!-- PR에 대한 간략한 설명을 적어주세요 -->
PrevButton과 NextButton 컴포넌트를 구현했습니다.
## ✨ Changes
<!-- 변경된 내용들을 상세히 나열해 주세요 -->
- Pagination에 사용될 next prev버튼을 구현했습니다.

## 🖼️ Screenshots
<!-- 필요한 경우 스크린샷을 첨부해 주세요 -->
<img width="94" alt="image" src="https://github.com/user-attachments/assets/653339ee-424e-439b-bfb7-a41ff9a85b73">

## ✅ PR Checklist
<!-- 코드 리뷰 시 확인해야 할 사항들 -->
- [x] 하나의 목적을 가진 PR입니다.
- [x] 코딩 컨벤션과 스타일 가이드를 준수합니다. [📌Conventions](https://github.com/prgrms-fe-devcourse/NFE1-2-LocalStage/wiki/%F0%9F%93%8CConventions)
- [x] 불필요한 코드 중복이 없습니다.
- [x] 컴포넌트의 책임이 단일합니다.
- [x] 리액트 훅을 올바르게 사용했습니다.
- [x] 민감한 정보를 포함하지 않았습니다.
- [x] 불필요한 콘솔 로그나 주석을 포함하지 않았습니다.
- [ ] 컴포넌트 key값에 고유한 값을 할당했습니다.

## 🔗 References
<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->
- Issue: #158 

## 💬 Comments
<!-- 추가적인 커멘트가 있다면 작성해 주세요 -->
